### PR TITLE
add discussion of consistency of boundary conditions on pressure to appendix of report

### DIFF
--- a/report/srp-report.tex
+++ b/report/srp-report.tex
@@ -469,18 +469,23 @@ so that
 \chapter{Various Extensions and Proofs}
 
 \section{Rotational Scheme Still Consistent with Variable Viscosity but Constant Density}
-We verify that the artificial boundary conditions imposed on pressure by the rotational fix under assumptions of constant viscosity and density still hold when viscosity is no longer constant.  Mainly we will show that 
+We verify that the artificial boundary conditions imposed on pressure by the rotational fix under assumptions of constant viscosity and density still roughly hold when viscosity is no longer constant.  Mainly we will show that 
 \begin{equation}
   \left.\frac{\partial p^{k+1}}{\partial \n}\right|_{\partial\Omega} = \left.\left(f^{k+1} + \nabla\cdot\ut^{k+1}\nabla\mu - \nabla\times\left(\mu\nabla\times \ub^{k+1}  \right)  \right)\cdot \n\right|_{\partial\Omega}
 \end{equation}
-which is a consistent pressure boundary condition.  Compare this to the imposed boundary condition when viscosity is assumed constant
+which is almost a consistent pressure boundary condition.  Compare this to the imposed boundary condition when viscosity is assumed constant
 \begin{equation}
   \left.\frac{\partial p^{k+1}}{\partial \n}\right|_{\partial\Omega} = \left.\left(f^{k+1} - \mu\nabla\times\nabla\times \ub^{k+1} \right)\cdot \n\right|_{\partial\Omega}
 \end{equation}
- as discussed in \cite{guermond2004error}.  Thus again we are left with the only distortions from the operator splitting being manifest as the tangential velocity requirement
+ as discussed in \cite{guermond2004error}.  
+ 
+ Thus we are left with the  distortions from the operator splitting being manifest as the tangential velocity requirement
 \begin{equation}
   \left.\ub^{k+1}\cdot\n\right|_{\partial\Omega} = 0.
 \end{equation}
+and an extra penalty term manifesting in the normal pressure gradient scaled by $\nabla\cdot\ut^{k+1}$.  
+
+
 
 %
 %
@@ -492,7 +497,13 @@ The following identities on a smooth vector function $\Ab$ will be of use to us:
   \nabla\left( \mu \nabla\cdot \Ab\right) &= \mu\nabla\left(\nabla\cdot \Ab\right) + \left( \nabla\cdot \Ab\right)\nabla\mu\label{eqn:gradmudividentity}
 \end{align}
 
-To proceed with the proof, we start with the initial scheme (any BDF formula for time derivative will work but we give proof in terms of BDF1)
+Recall that we are approximating the solution to the continuous equations
+\begin{numcases}{}
+  \rho\left(\frac{\partial \ub}{\partial t}  + \ub\cdot\nabla\ub\right) - \nabla\left(\cdot\mu \nabla\ub\right) + \nabla p = \fb\label{eqn:continuousmomentumequation}\\
+  \left.\ub\right|_{\partial\Omega} = 0\label{eqn:continuousvelocitydirichletbc}\\
+  \nabla\cdot\ub = 0\label{eqn:continuousdivergencevelocityequalszero}
+\end{numcases}
+with constant density and variable viscosity.  To proceed with the proof, we start with the initial scheme (any BDF formula for time derivative will work but we give proof in terms of BDF1)
 \begin{numcases}{}
   \frac{\rho}{\tau}\left( \ut^{k+1} - \ub^{k}\right) + \rho \ut^{k}\cdot\nabla\ut^{k+1} - \nabla\cdot\left(\mu\nabla\ut^{k+1}\right) + \nabla p^{k} = \fb^{k+1},\label{eqn:initialmomentum}\\ 
   \left.\ut^{k+1}\right|_{\partial\Omega} = 0,\\
@@ -518,10 +529,18 @@ So by plugging equations (\ref{eqn:initialprojection}) and (\ref{eqn:initialpres
 By dotting (\ref{eqn:momentumcwithurlculequation}) with $\n$ and restricting to boundary and using properties (\ref{eqn:utildeonboundaryequalszero}) and (\ref{eqn:tangentialuonboundaryequalszero}), we get the normal pressure gradient condition
 
 \begin{equation}
-  \left.\frac{\partial p^{k+1}}{\partial \n}\right|_{\partial\Omega} = \left.\left(f^{k+1} + \nabla\cdot\ut^{k+1}\nabla\mu - \nabla\times\left(\mu\nabla\times \ub^{k+1}  \right)  \right)\cdot \n\right|_{\partial\Omega}
+  \left.\frac{\partial p^{k+1}}{\partial \n}\right|_{\partial\Omega} = \left.\left(f^{k+1} + \nabla\cdot\ut^{k+1}\nabla\mu - \nabla\times\left(\mu\nabla\times \ub^{k+1}  \right)  \right)\cdot \n\right|_{\partial\Omega}.
 \end{equation}
 
-which is in fact consistent with the momentum equation (\ref{eqn:initialmomentum}).
+Finally notice that because of (\ref{eqn:divuequalszero}) and (\ref{eqn:curlmucurlidentity}), we have 
+\begin{equation}
+  \nabla\times\left(\mu\nabla\times \ub^{k+1}\right) = \nabla\cdot\left(\mu\nabla\ub^{k+1}\right)
+\end{equation}
+so 
+\begin{equation}
+  \left.\frac{\partial p^{k+1}}{\partial \n}\right|_{\partial\Omega} = \left.\left(f^{k+1} + \nabla\cdot\left(\mu\nabla\ub^{k+1}\right) \right)\cdot \n\right|_{\partial\Omega} + \left.\nabla\cdot\ut^{k+1}\frac{\partial\mu}{\partial\n}\right|_{\partial\Omega},
+\end{equation}
+which is almost consistent with the momentum equation (\ref{eqn:continuousmomentumequation}).  The inconsistency comes from the $\nabla\cdot\ut^{k+1}\frac{\partial\mu}{\partial\n}$ term which can be seen as a penalty term for the normal pressure gradient.
 
 
 


### PR DESCRIPTION
@cekees @mfarthin Could you look over the appendix discussion of the report https://github.com/erdc-cm/proteus-ps/blob/srobertp/tweakReport/report/srp-report.pdf , specifically the final couple paragraphs where we are summarizing the consistency results.  I want to say that the scheme is consistent with the continuous equations but I am hesitant to say so because of that divergence of the u tilde times the normal derivative of viscosity.  If it were divergence of u, then definitely but I am not quite sure how to interpret that extra term.

Any thoughts on the matter would be helpful.  It will definitely be interesting to see how well the scheme handles things if we do give it a variable viscosity.  Do we obtain the full O(dt^{3/2}) as in the pressure and H1 norms of velocity for constant viscosity?  I realize that this is a side note but it plays into future expectations of the model and whether or not we should leave a switch for the rotational scheme to be turned on and off.  
