### PR TITLE
srobertp/addVarDensityPSBDF1:  First implementation of the bdf1 algorithm

### DIFF
--- a/NavierStokesNotebooks/VariableDensityNavierStokes2D/L2_batch.py
+++ b/NavierStokesNotebooks/VariableDensityNavierStokes2D/L2_batch.py
@@ -30,21 +30,21 @@ simFlagsList[1]['dataDir']        = os.getcwd()+'/results_BDF%1d' %int(float(ctx
 simFlagsList[1]['storeQuantities']= ['simulationData','errorData'] #include errorData for mass bal
 simFlagsList[1]['storeTimes']     = ['Last']
 
-# # Pressure Increment
-# simFlagsList[2]['errorQuantities']=['u']
-# simFlagsList[2]['errorTypes']= ['numericalSolution'] #compute error in soln and glob. mass bal
-# simFlagsList[2]['errorNorms']= ['L2'] #compute L2 norm in space or H1 or ...
-# simFlagsList[2]['errorTimes']= ['All'] #'All', 'Last'
-# simFlagsList[2]['echo']=True
-# simFlagsList[2]['dataFile']       = simFlagsList[2]['simulationName'] + "_DT_0_%s_BDF%1d.db" %(ctx.DT_string,int(float(ctx.globalBDFTimeOrder)))
-# simFlagsList[2]['dataDir']        = os.getcwd()+'/results_BDF%1d' %int(float(ctx.globalBDFTimeOrder))
-# simFlagsList[2]['storeQuantities']= ['simulationData','errorData'] #include errorData for mass bal
-# simFlagsList[2]['storeTimes']     = ['Last']
+# Pressure Increment
+simFlagsList[2]['errorQuantities']=['u']
+simFlagsList[2]['errorTypes']= ['numericalSolution'] #compute error in soln and glob. mass bal
+simFlagsList[2]['errorNorms']= ['L2'] #compute L2 norm in space or H1 or ...
+simFlagsList[2]['errorTimes']= ['All'] #'All', 'Last'
+simFlagsList[2]['echo']=True
+simFlagsList[2]['dataFile']       = simFlagsList[2]['simulationName'] + "_DT_0_%s_BDF%1d.db" %(ctx.DT_string,int(float(ctx.globalBDFTimeOrder)))
+simFlagsList[2]['dataDir']        = os.getcwd()+'/results_BDF%1d' %int(float(ctx.globalBDFTimeOrder))
+simFlagsList[2]['storeQuantities']= ['simulationData','errorData'] #include errorData for mass bal
+simFlagsList[2]['storeTimes']     = ['Last']
 
 # Pressure
 simFlagsList[3]['errorQuantities']=['u']
 simFlagsList[3]['errorTypes']= ['numericalSolution'] #compute error in soln and glob. mass bal
-simFlagsList[3]['errorNorms']= ['L2'] #compute L2 norm in space or H1 or ...
+simFlagsList[3]['errorNorms']= ['L2','H1semi'] #compute L2 norm in space or H1 or ...
 simFlagsList[3]['errorTimes']= ['All'] #'All', 'Last'
 simFlagsList[3]['echo']=True
 simFlagsList[3]['dataFile']       = simFlagsList[3]['simulationName'] + "_DT_0_%s_BDF%1d.db" %(ctx.DT_string,int(float(ctx.globalBDFTimeOrder)))

--- a/NavierStokesNotebooks/VariableDensityNavierStokes2D/NavierStokesVariableDensity.py
+++ b/NavierStokesNotebooks/VariableDensityNavierStokes2D/NavierStokesVariableDensity.py
@@ -58,6 +58,7 @@ class DensityTransport2D(TransportCoefficients.TC_base):
                                                variableNames = ['rho'],
                                                mass = {0:{0:'linear'}},
                                                advection = {0:{0:'linear'}},
+                                               #hamiltonian = {0:{0:'linear'}},
                                                reaction = {0:{0:'linear'}} if useStabilityTerms else {} ) # for the stability term
         self.bdf=int(bdf)
         self.currentModelIndex = currentModelIndex
@@ -311,8 +312,8 @@ class DensityTransport2D(TransportCoefficients.TC_base):
         Evaluate the coefficients after getting the specified velocity
         """
         rho = c[('u',0)]
-        if self.bdf is int(2) and not self.firstStep:
-            grad_rho = c[('grad(u)',0)]
+        # if self.bdf is int(2) and not self.firstStep:
+        #     grad_rho = c[('grad(u)',0)]
 
         # If we use pressureIncrementModel.q[('velocity',)] for our velocity, then we must
         # adjust it to be scaled properly by multiplying by dt/chi.  Then it is physical velocity
@@ -374,17 +375,17 @@ class DensityTransport2D(TransportCoefficients.TC_base):
         #  bdf2:  rho_t + vel_star \cdot grad_rho - 0.5 rho div( vel_star ) = 0
         c[('m',0)][:] = rho
         c[('dm',0,0)][:] = 1.0
-        if self.bdf is int(1) or self.firstStep:
-            c[('f',0)][...,0] = rho*u_star
-            c[('f',0)][...,1] = rho*v_star
-            c[('df',0,0)][...,0] = u_star
-            c[('df',0,0)][...,1] = v_star
-        elif self.bdf is int(2):
-            c[('H',0)][:] = u_star*grad_rho[...,0] + v_star*grad_rho[...,1]
-            c[('dH',0,0)][...,0] = u_star #  dH d(u_x)
-            c[('dH',0,0)][...,1] = v_star #  dH d(u_y)
-        else:
-            assert False, "Error: self.bdf = %f is not supported" %self.bdf
+        # if self.bdf is int(1) or self.firstStep:
+        c[('f',0)][...,0] = rho*u_star
+        c[('f',0)][...,1] = rho*v_star
+        c[('df',0,0)][...,0] = u_star
+        c[('df',0,0)][...,1] = v_star
+        # elif self.bdf is int(2):
+        #     c[('H',0)][:] = u_star*grad_rho[...,0] + v_star*grad_rho[...,1]
+        #     c[('dH',0,0)][...,0] = u_star #  dH d(u_x)
+        #     c[('dH',0,0)][...,1] = v_star #  dH d(u_y)
+        # else:
+        #     assert False, "Error: self.bdf = %f is not supported" %self.bdf
         if self.useStabilityTerms:
             c[('r',0)][:]    = -0.5*rho*div_vel_star
             c[('dr',0,0)][:] = -0.5*div_vel_star

--- a/NavierStokesNotebooks/VariableDensityNavierStokes2D/NavierStokesVariableDensity.py
+++ b/NavierStokesNotebooks/VariableDensityNavierStokes2D/NavierStokesVariableDensity.py
@@ -311,6 +311,8 @@ class DensityTransport2D(TransportCoefficients.TC_base):
         Evaluate the coefficients after getting the specified velocity
         """
         rho = c[('u',0)]
+        if self.bdf is int(2) and not self.firstStep:
+            grad_rho = c[('grad(u)',0)]
 
         # If we use pressureIncrementModel.q[('velocity',)] for our velocity, then we must
         # adjust it to be scaled properly by multiplying by dt/chi.  Then it is physical velocity
@@ -368,18 +370,24 @@ class DensityTransport2D(TransportCoefficients.TC_base):
         else:
             assert False, "Error: self.bdf = %f is not supported" %self.bdf
 
-        # note that coefficients formulas are the same for bdf1 and bdf2 for density transport
+        #  bdf1:  rho_t + div( rho vel_star) - 0.5 rho div( vel_star ) = 0
+        #  bdf2:  rho_t + vel_star \cdot grad_rho - 0.5 rho div( vel_star ) = 0
         c[('m',0)][:] = rho
         c[('dm',0,0)][:] = 1.0
-        c[('f',0)][...,0] = rho*u_star
-        c[('f',0)][...,1] = rho*v_star
-        c[('df',0,0)][...,0] = u_star
-        c[('df',0,0)][...,1] = v_star
+        if self.bdf is int(1) or self.firstStep:
+            c[('f',0)][...,0] = rho*u_star
+            c[('f',0)][...,1] = rho*v_star
+            c[('df',0,0)][...,0] = u_star
+            c[('df',0,0)][...,1] = v_star
+        elif self.bdf is int(2):
+            c[('H',0)][:] = u_star*grad_phi[...,0] + v_star*grad_phi[...,1]
+            c[('dH',0,0)][...,0] = u_star #  dH d(u_x)
+            c[('dH',0,0)][...,1] = v_star #  dH d(u_y)
+        else:
+            assert False, "Error: self.bdf = %f is not supported" %self.bdf
         if self.useStabilityTerms:
             c[('r',0)][:]    = -0.5*rho*div_vel_star
             c[('dr',0,0)][:] = -0.5*div_vel_star
-
-
 
 
 

--- a/NavierStokesNotebooks/VariableDensityNavierStokes2D/NavierStokesVariableDensity.py
+++ b/NavierStokesNotebooks/VariableDensityNavierStokes2D/NavierStokesVariableDensity.py
@@ -380,7 +380,7 @@ class DensityTransport2D(TransportCoefficients.TC_base):
             c[('df',0,0)][...,0] = u_star
             c[('df',0,0)][...,1] = v_star
         elif self.bdf is int(2):
-            c[('H',0)][:] = u_star*grad_phi[...,0] + v_star*grad_phi[...,1]
+            c[('H',0)][:] = u_star*grad_rho[...,0] + v_star*grad_rho[...,1]
             c[('dH',0,0)][...,0] = u_star #  dH d(u_x)
             c[('dH',0,0)][...,1] = v_star #  dH d(u_y)
         else:


### PR DESCRIPTION
The base algorithm is implemented and runs with parun but needs to be tested more to ensure accuracy.  The post processing on the third model (pressure increment) needs to be further tested and we need to decide what to use for velocity_last in the velocity model when using the post processing.  Should we use  the post processed velocity or the un processed velocity?  

solves #31 

There is still some work to be done before we can merge and close this branch, but I wanted to set up this pull request as a location to discuss the progress of this work.

The algorithm without post processing should give first order convergence on every norm as computed by L2_Batch.py and still needs to be tested.  

Likewise, we need to test the boundary conditions for the third model.  Currently a flag called 'fixed' has been set on one of the dofs on the boundary.  The dirichlet conditions are set to 0 for that dof only.  this allows us to solve the laplacian system with 0 neumann boundary conditions.  The postStep() function then adjusts the mean value to be 0.  We need to test this more fully to make sure it is behaving the way we want it to.
