### PR TITLE
Test bdf2 only simple algorithm

### DIFF
--- a/NavierStokesNotebooks/VariableDensityNavierStokes2D/NavierStokesVariableDensity.py
+++ b/NavierStokesNotebooks/VariableDensityNavierStokes2D/NavierStokesVariableDensity.py
@@ -26,6 +26,7 @@ class DensityTransport2D(TransportCoefficients.TC_base):
     def __init__(self,
                  bdf=1,
                  currentModelIndex=0,
+                 densityFunction=None,
                  velocityModelIndex=-1,
                  velocityFunction=None,
                  divVelocityFunction=None,
@@ -62,6 +63,7 @@ class DensityTransport2D(TransportCoefficients.TC_base):
                                                reaction = {0:{0:'linear'}} if useStabilityTerms else {} ) # for the stability term
         self.bdf=int(bdf)
         self.currentModelIndex = currentModelIndex
+        self.densityFunction=densityFunction
         self.velocityModelIndex = velocityModelIndex
         self.velocityFunction = velocityFunction
         self.divVelocityFunction = divVelocityFunction
@@ -78,7 +80,6 @@ class DensityTransport2D(TransportCoefficients.TC_base):
         self.c_grad_v_last = {}
         self.c_grad_u_lastlast = {}
         self.c_grad_v_lastlast = {}
-        # self.c_grad_velocity_last = {}
         self.useStabilityTerms = useStabilityTerms
         self.firstStep = True # manipulated in preStep()
 
@@ -108,10 +109,10 @@ class DensityTransport2D(TransportCoefficients.TC_base):
         self.model.points_quadrature.add(('u_last',0))
         self.model.points_elementBoundaryQuadrature.add(('u_last',0))
         self.model.numericalFlux.ebqe[('u_last',0)] = self.model.ebqe[('u_last',0)]
-        if self.bdf is int(2):
-            self.model.points_quadrature.add(('u_lastlast',0))
-            self.model.points_elementBoundaryQuadrature.add(('u_lastlast',0))
-            self.model.numericalFlux.ebqe[('u_lastlast',0)] = self.model.ebqe[('u_lastlast',0)]
+        # if self.bdf is int(2):
+        self.model.points_quadrature.add(('u_lastlast',0))
+        self.model.points_elementBoundaryQuadrature.add(('u_lastlast',0))
+        self.model.numericalFlux.ebqe[('u_lastlast',0)] = self.model.ebqe[('u_lastlast',0)]
 
         if (not self.useVelocityComponents and self.velocityModelIndex >= 0 and
                self.velocityFunction is None):
@@ -125,35 +126,35 @@ class DensityTransport2D(TransportCoefficients.TC_base):
             if ('velocity',0) in self.pressureIncrementModel.q:
                 vel_last = self.pressureIncrementModel.q[('velocity',0)] # velocity is from previous time step so is called _last here
                 self.c_velocity_last[vel_last.shape] = vel_last
-                if self.useStabilityTerms:
-                    grad_u_last = self.velocityModel.q[('grad(u)',0)]
-                    grad_v_last = self.velocityModel.q[('grad(u)',1)]
-                    self.c_grad_u_last[grad_u_last.shape] = grad_u_last
-                    self.c_grad_v_last[grad_v_last.shape] = grad_v_last
+                # if self.useStabilityTerms:
+                grad_u_last = self.velocityModel.q[('grad(u)',0)]
+                grad_v_last = self.velocityModel.q[('grad(u)',1)]
+                self.c_grad_u_last[grad_u_last.shape] = grad_u_last
+                self.c_grad_v_last[grad_v_last.shape] = grad_v_last
             if ('velocity',0) in self.pressureIncrementModel.ebq:
                 vel_last = self.pressureIncrementModel.ebq[('velocity',0)]
                 self.c_velocity_last[vel_last.shape] = vel_last
-                if self.useStabilityTerms:
-                    grad_u_last = self.velocityModel.ebq[('grad(u)',0)]
-                    grad_v_last = self.velocityModel.ebq[('grad(u)',1)]
-                    self.c_grad_u_last[grad_u_last.shape] = grad_u_last
-                    self.c_grad_v_last[grad_v_last.shape] = grad_v_last
+                # if self.useStabilityTerms:
+                grad_u_last = self.velocityModel.ebq[('grad(u)',0)]
+                grad_v_last = self.velocityModel.ebq[('grad(u)',1)]
+                self.c_grad_u_last[grad_u_last.shape] = grad_u_last
+                self.c_grad_v_last[grad_v_last.shape] = grad_v_last
             if ('velocity',0) in self.pressureIncrementModel.ebqe:
                 vel_last = self.pressureIncrementModel.ebqe[('velocity',0)]
                 self.c_velocity_last[vel_last.shape] = vel_last
-                if self.useStabilityTerms:
-                    grad_u_last = self.velocityModel.ebqe[('grad(u)',0)]
-                    grad_v_last = self.velocityModel.ebqe[('grad(u)',1)]
-                    self.c_grad_u_last[grad_u_last.shape] = grad_u_last
-                    self.c_grad_v_last[grad_v_last.shape] = grad_v_last
+                # if self.useStabilityTerms:
+                grad_u_last = self.velocityModel.ebqe[('grad(u)',0)]
+                grad_v_last = self.velocityModel.ebqe[('grad(u)',1)]
+                self.c_grad_u_last[grad_u_last.shape] = grad_u_last
+                self.c_grad_v_last[grad_v_last.shape] = grad_v_last
             if ('velocity',0) in self.pressureIncrementModel.ebq_global:
                 vel_last = self.pressureIncrementModel.ebq_global[('velocity',0)]
                 self.c_velocity_last[vel_last.shape] = vel_last
-                if self.useStabilityTerms:
-                    grad_u_last = self.velocityModel.ebq_global[('grad(u)',0)]
-                    grad_v_last = self.velocityModel.ebq_global[('grad(u)',1)]
-                    self.c_grad_u_last[grad_u_last.shape] = grad_u_last
-                    self.c_grad_v_last[grad_v_last.shape] = grad_v_last
+                # if self.useStabilityTerms:
+                grad_u_last = self.velocityModel.ebq_global[('grad(u)',0)]
+                grad_v_last = self.velocityModel.ebq_global[('grad(u)',1)]
+                self.c_grad_u_last[grad_u_last.shape] = grad_u_last
+                self.c_grad_v_last[grad_v_last.shape] = grad_v_last
         elif (self.useVelocityComponents and self.velocityModelIndex >= 0 and
               self.velocityFunction is None):
             assert self.velocityModelIndex < len(modelList), \
@@ -164,81 +165,81 @@ class DensityTransport2D(TransportCoefficients.TC_base):
                 v_last = self.velocityModel.q[('u',1)]
                 self.c_u_last[u_last.shape] = u_last
                 self.c_v_last[v_last.shape] = v_last
-                if self.useStabilityTerms:
-                    grad_u_last = self.velocityModel.q[('grad(u)',0)]
-                    grad_v_last = self.velocityModel.q[('grad(u)',1)]
-                    self.c_grad_u_last[grad_u_last.shape] = grad_u_last
-                    self.c_grad_v_last[grad_v_last.shape] = grad_v_last
-                if self.bdf is int(2):
-                    u_lastlast = self.velocityModel.q[('u_last',0)]
-                    v_lastlast = self.velocityModel.q[('u_last',1)]
-                    self.c_u_lastlast[u_lastlast.shape] = u_lastlast
-                    self.c_v_lastlast[v_lastlast.shape] = v_lastlast
-                    if self.useStabilityTerms:
-                        grad_u_lastlast = self.velocityModel.q[('grad(u)_last',0)]
-                        grad_v_lastlast = self.velocityModel.q[('grad(u)_last',1)]
-                        self.c_grad_u_lastlast[grad_u_lastlast.shape] = grad_u_lastlast
-                        self.c_grad_v_lastlast[grad_v_lastlast.shape] = grad_v_lastlast
+                # if self.useStabilityTerms:
+                grad_u_last = self.velocityModel.q[('grad(u)',0)]
+                grad_v_last = self.velocityModel.q[('grad(u)',1)]
+                self.c_grad_u_last[grad_u_last.shape] = grad_u_last
+                self.c_grad_v_last[grad_v_last.shape] = grad_v_last
+                # if self.bdf is int(2):
+                u_lastlast = self.velocityModel.q[('u_last',0)]
+                v_lastlast = self.velocityModel.q[('u_last',1)]
+                self.c_u_lastlast[u_lastlast.shape] = u_lastlast
+                self.c_v_lastlast[v_lastlast.shape] = v_lastlast
+                    # if self.useStabilityTerms:
+                grad_u_lastlast = self.velocityModel.q[('grad(u)_last',0)]
+                grad_v_lastlast = self.velocityModel.q[('grad(u)_last',1)]
+                self.c_grad_u_lastlast[grad_u_lastlast.shape] = grad_u_lastlast
+                self.c_grad_v_lastlast[grad_v_lastlast.shape] = grad_v_lastlast
             if ('u',0) in self.velocityModel.ebq:
                 u_last = self.velocityModel.ebq[('u',0)]
                 v_last = self.velocityModel.ebq[('u',1)]
                 self.c_u_last[u_last.shape] = u_last
                 self.c_v_last[v_last.shape] = v_last
-                if self.useStabilityTerms:
-                    grad_u_last = self.velocityModel.ebq[('grad(u)',0)]
-                    grad_v_last = self.velocityModel.ebq[('grad(u)',1)]
-                    self.c_grad_u_last[grad_u_last.shape] = grad_u_last
-                    self.c_grad_v_last[grad_v_last.shape] = grad_v_last
-                if self.bdf is int(2):
-                    u_lastlast = self.velocityModel.ebq[('u_last',0)]
-                    v_lastlast = self.velocityModel.ebq[('u_last',1)]
-                    self.c_u_lastlast[u_lastlast.shape] = u_lastlast
-                    self.c_v_lastlast[v_lastlast.shape] = v_lastlast
-                    if self.useStabilityTerms:
-                        grad_u_lastlast = self.velocityModel.ebq[('grad(u)_last',0)]
-                        grad_v_lastlast = self.velocityModel.ebq[('grad(u)_last',1)]
-                        self.c_grad_u_lastlast[grad_u_lastlast.shape] = grad_u_lastlast
-                        self.c_grad_v_lastlast[grad_v_lastlast.shape] = grad_v_lastlast
+                # if self.useStabilityTerms:
+                grad_u_last = self.velocityModel.ebq[('grad(u)',0)]
+                grad_v_last = self.velocityModel.ebq[('grad(u)',1)]
+                self.c_grad_u_last[grad_u_last.shape] = grad_u_last
+                self.c_grad_v_last[grad_v_last.shape] = grad_v_last
+                # if self.bdf is int(2):
+                u_lastlast = self.velocityModel.ebq[('u_last',0)]
+                v_lastlast = self.velocityModel.ebq[('u_last',1)]
+                self.c_u_lastlast[u_lastlast.shape] = u_lastlast
+                self.c_v_lastlast[v_lastlast.shape] = v_lastlast
+                    # if self.useStabilityTerms:
+                grad_u_lastlast = self.velocityModel.ebq[('grad(u)_last',0)]
+                grad_v_lastlast = self.velocityModel.ebq[('grad(u)_last',1)]
+                self.c_grad_u_lastlast[grad_u_lastlast.shape] = grad_u_lastlast
+                self.c_grad_v_lastlast[grad_v_lastlast.shape] = grad_v_lastlast
             if ('u',0) in self.velocityModel.ebqe:
                 u_last = self.velocityModel.ebqe[('u',0)]
                 v_last = self.velocityModel.ebqe[('u',1)]
                 self.c_u_last[u_last.shape] = u_last
                 self.c_v_last[v_last.shape] = v_last
-                if self.useStabilityTerms:
-                    grad_u_last = self.velocityModel.ebqe[('grad(u)',0)]
-                    grad_v_last = self.velocityModel.ebqe[('grad(u)',1)]
-                    self.c_grad_u_last[grad_u_last.shape] = grad_u_last
-                    self.c_grad_v_last[grad_v_last.shape] = grad_v_last
-                if self.bdf is int(2):
-                    u_lastlast = self.velocityModel.ebqe[('u_last',0)]
-                    v_lastlast = self.velocityModel.ebqe[('u_last',1)]
-                    self.c_u_lastlast[u_lastlast.shape] = u_lastlast
-                    self.c_v_lastlast[v_lastlast.shape] = v_lastlast
-                    if self.useStabilityTerms:
-                        grad_u_lastlast = self.velocityModel.ebqe[('grad(u)_last',0)]
-                        grad_v_lastlast = self.velocityModel.ebqe[('grad(u)_last',1)]
-                        self.c_grad_u_lastlast[grad_u_lastlast.shape] = grad_u_lastlast
-                        self.c_grad_v_lastlast[grad_v_lastlast.shape] = grad_v_lastlast
+                # if self.useStabilityTerms:
+                grad_u_last = self.velocityModel.ebqe[('grad(u)',0)]
+                grad_v_last = self.velocityModel.ebqe[('grad(u)',1)]
+                self.c_grad_u_last[grad_u_last.shape] = grad_u_last
+                self.c_grad_v_last[grad_v_last.shape] = grad_v_last
+                # if self.bdf is int(2):
+                u_lastlast = self.velocityModel.ebqe[('u_last',0)]
+                v_lastlast = self.velocityModel.ebqe[('u_last',1)]
+                self.c_u_lastlast[u_lastlast.shape] = u_lastlast
+                self.c_v_lastlast[v_lastlast.shape] = v_lastlast
+                    # if self.useStabilityTerms:
+                grad_u_lastlast = self.velocityModel.ebqe[('grad(u)_last',0)]
+                grad_v_lastlast = self.velocityModel.ebqe[('grad(u)_last',1)]
+                self.c_grad_u_lastlast[grad_u_lastlast.shape] = grad_u_lastlast
+                self.c_grad_v_lastlast[grad_v_lastlast.shape] = grad_v_lastlast
             if ('u',0) in self.velocityModel.ebq_global:
                 u_last = self.velocityModel.ebq_global[('u',0)]
                 v_last = self.velocityModel.ebq_global[('u',1)]
                 self.c_u_last[u_last.shape] = u_last
                 self.c_v_last[v_last.shape] = v_last
-                if self.useStabilityTerms:
-                    grad_u_last = self.velocityModel.ebq_global[('grad(u)',0)]
-                    grad_v_last = self.velocityModel.ebq_global[('grad(u)',1)]
-                    self.c_grad_u_last[grad_u_last.shape] = grad_u_last
-                    self.c_grad_v_last[grad_v_last.shape] = grad_v_last
-                if self.bdf is int(2):
-                    u_lastlast = self.velocityModel.ebq_global[('u_last',0)]
-                    v_lastlast = self.velocityModel.ebq_global[('u_last',1)]
-                    self.c_u_lastlast[u_lastlast.shape] = u_lastlast
-                    self.c_v_lastlast[v_lastlast.shape] = v_lastlast
-                    if self.useStabilityTerms:
-                        grad_u_lastlast = self.velocityModel.ebq_global[('grad(u)_last',0)]
-                        grad_v_lastlast = self.velocityModel.ebq_global[('grad(u)_last',1)]
-                        self.c_grad_u_lastlast[grad_u_lastlast.shape] = grad_u_lastlast
-                        self.c_grad_v_lastlast[grad_v_lastlast.shape] = grad_v_lastlast
+                # if self.useStabilityTerms:
+                grad_u_last = self.velocityModel.ebq_global[('grad(u)',0)]
+                grad_v_last = self.velocityModel.ebq_global[('grad(u)',1)]
+                self.c_grad_u_last[grad_u_last.shape] = grad_u_last
+                self.c_grad_v_last[grad_v_last.shape] = grad_v_last
+                # if self.bdf is int(2):
+                u_lastlast = self.velocityModel.ebq_global[('u_last',0)]
+                v_lastlast = self.velocityModel.ebq_global[('u_last',1)]
+                self.c_u_lastlast[u_lastlast.shape] = u_lastlast
+                self.c_v_lastlast[v_lastlast.shape] = v_lastlast
+                    # if self.useStabilityTerms:
+                grad_u_lastlast = self.velocityModel.ebq_global[('grad(u)_last',0)]
+                grad_v_lastlast = self.velocityModel.ebq_global[('grad(u)_last',1)]
+                self.c_grad_u_lastlast[grad_u_lastlast.shape] = grad_u_lastlast
+                self.c_grad_v_lastlast[grad_v_lastlast.shape] = grad_v_lastlast
     def initializeMesh(self,mesh):
         """
         Give the TC object access to the mesh for any mesh-dependent information.
@@ -251,8 +252,8 @@ class DensityTransport2D(TransportCoefficients.TC_base):
         for ci in range(self.nc):
             cq[('u_last',ci)] = deepcopy(cq[('u',ci)])
             #cq[('grad(u)_last',ci)] = deepcopy(cq[('grad(u)',ci)])
-            if self.bdf is int(2):
-                cq[('u_lastlast',ci)] = deepcopy(cq[('u',ci)])
+            # if self.bdf is int(2):
+            cq[('u_lastlast',ci)] = deepcopy(cq[('u',ci)])
                 # #cq[('grad(u)_lastlast',ci)] = deepcopy(cq[('grad(u)_last',ci)])
     def initializeElementBoundaryQuadrature(self,t,cebq,cebq_global):
         """
@@ -271,8 +272,8 @@ class DensityTransport2D(TransportCoefficients.TC_base):
         for ci in range(self.nc):
             cebqe[('u_last',ci)] = deepcopy(cebqe[('u',ci)])
             #cebqe[('grad(u)_last',ci)] = deepcopy(cebqe[('grad(u)',ci)])
-            if self.bdf is int(2):
-                cebqe[('u_lastlast',ci)] = deepcopy(cebqe[('u',ci)])
+            # if self.bdf is int(2):
+            cebqe[('u_lastlast',ci)] = deepcopy(cebqe[('u',ci)])
                 # #cebqe[('grad(u)_lastlast',ci)] = deepcopy(cebqe[('grad(u)',ci)])
 
     def initializeGeneralizedInterpolationPointQuadrature(self,t,cip):
@@ -309,6 +310,17 @@ class DensityTransport2D(TransportCoefficients.TC_base):
             # self.model.ebq_global[('grad(u)_last',ci)][:] = self.model.ebq_global[('grad(u)',ci)]
         copyInstructions = {}
         return copyInstructions
+    def postStep(self,t,firstStep=False):
+        """
+        Give the TC object an opportunity to modify itself before the time step.
+        """
+        if (firstStep and t>0):
+            self.model.q[('u',0)][:] = self.densityFunction(self.model.q['x'],t)
+            self.model.ebqe[('u',0)] = self.densityFunction(self.model.ebqe['x'],t)
+            self.model.u[0].dof[:] = self.densityFunction(self.model.mesh.nodeArray,t)
+
+        copyInstructions = {}
+        return copyInstructions
     def evaluate(self,t,c):
         """
         Evaluate the coefficients after getting the specified velocity
@@ -328,17 +340,17 @@ class DensityTransport2D(TransportCoefficients.TC_base):
         if self.bdf is int(2) and not self.firstStep:
             tLastLast = tLast - dt_last
 
-        # extract scaling terms for post processed velocity (see pressureIncrement model for description)
-        if not self.useVelocityComponents and self.velocityFunction is None:
-            chi = self.chiValue
-            # beta_0 coefficient scalar
-            if self.bdf is int(1) or self.firstStep:
-                b0 = 1.0/dt
-            elif self.bdf is int(2):
-                r = dt/dt_last
-                dtInv = 1.0/dt
-                b0 = (1.0+2.0*r)/(1.0+r)*dtInv  # = self.model.timeIntegration.alpha_bdf  # = beta_0
-            Invb0chi = 1.0/(chi*b0)
+        # # extract scaling terms for post processed velocity (see pressureIncrement model for description)
+        # if not self.useVelocityComponents and self.velocityFunction is None:
+        #     chi = self.chiValue
+        #     # beta_0 coefficient scalar
+        #     if self.bdf is int(1) or self.firstStep:
+        #         b0 = 1.0/dt
+        #     elif self.bdf is int(2):
+        #         r = dt/dt_last
+        #         dtInv = 1.0/dt
+        #         b0 = (1.0+2.0*r)/(1.0+r)*dtInv  # = self.model.timeIntegration.alpha_bdf  # = beta_0
+        #     Invb0chi = 1.0/(chi*b0)
 
 
         # extract last velocity components
@@ -352,11 +364,11 @@ class DensityTransport2D(TransportCoefficients.TC_base):
             v_last = self.c_v_last[c[('m',0)].shape]
             if self.useStabilityTerms:
                 div_vel_last = self.c_grad_u_last[c[('f',0)].shape][...,0] + self.c_grad_v_last[c[('f',0)].shape][...,1]
-        else:
-            u_last = Invb0chi*self.c_velocity_last[c[('f',0)].shape][...,0]  # make adjustment to physical values here by mult by dt/chi
-            v_last = Invb0chi*self.c_velocity_last[c[('f',0)].shape][...,1]  # make adjustment to physical values here by mult by dt/chi
-            if self.useStabilityTerms:
-                div_vel_last = self.c_grad_u_last[c[('f',0)].shape][...,0] + self.c_grad_v_last[c[('f',0)].shape][...,1]
+        # else:
+        #     u_last = Invb0chi*self.c_velocity_last[c[('f',0)].shape][...,0]  # make adjustment to physical values here by mult by dt/chi
+        #     v_last = Invb0chi*self.c_velocity_last[c[('f',0)].shape][...,1]  # make adjustment to physical values here by mult by dt/chi
+        #     if self.useStabilityTerms:
+        #         div_vel_last = self.c_grad_u_last[c[('f',0)].shape][...,0] + self.c_grad_v_last[c[('f',0)].shape][...,1]
 
         # extract the lastlast time step values as needed
         if self.bdf is int(2) and not self.firstStep:
@@ -444,6 +456,8 @@ class VelocityTransport2D(TransportCoefficients.TC_base):
                  densityModelIndex=-1,
                  densityFunction=None,
                  densityGradFunction=None,
+                 uFunction=None,
+                 vFunction=None,
                  pressureIncrementModelIndex=-1,
                  pressureIncrementGradFunction=None,
                  pressureModelIndex=-1,
@@ -483,6 +497,8 @@ class VelocityTransport2D(TransportCoefficients.TC_base):
         self.densityModelIndex = densityModelIndex
         self.densityFunction = densityFunction
         self.densityGradFunction = densityGradFunction
+        self.uFunction=uFunction
+        self.vFunction=vFunction
         self.pressureModelIndex = pressureModelIndex
         self.pressureGradFunction = pressureGradFunction
         self.pressureIncrementModelIndex = pressureIncrementModelIndex
@@ -512,13 +528,13 @@ class VelocityTransport2D(TransportCoefficients.TC_base):
             self.model.points_elementBoundaryQuadrature.add(('u_last',ci))
             self.model.vectors_elementBoundaryQuadrature.add(('grad(u)_last',ci))
             self.model.numericalFlux.ebqe[('grad(u)_last',ci)]=self.model.ebqe[('grad(u)_last',ci)]
-            if self.bdf is int(2):
-                self.model.points_quadrature.add(('u_lastlast',ci))
-                self.model.vectors_quadrature.add(('grad(u)_lastlast',ci))
-                self.model.numericalFlux.ebqe[('u_lastlast',ci)]=self.model.ebqe[('u_lastlast',ci)]
-                self.model.points_elementBoundaryQuadrature.add(('u_lastlast',ci))
-                self.model.vectors_elementBoundaryQuadrature.add(('grad(u)_lastlast',ci))
-                self.model.numericalFlux.ebqe[('grad(u)_lastlast',ci)]=self.model.ebqe[('grad(u)_lastlast',ci)]
+            # if self.bdf is int(2):
+            self.model.points_quadrature.add(('u_lastlast',ci))
+            self.model.vectors_quadrature.add(('grad(u)_lastlast',ci))
+            self.model.numericalFlux.ebqe[('u_lastlast',ci)]=self.model.ebqe[('u_lastlast',ci)]
+            self.model.points_elementBoundaryQuadrature.add(('u_lastlast',ci))
+            self.model.vectors_elementBoundaryQuadrature.add(('grad(u)_lastlast',ci))
+            self.model.numericalFlux.ebqe[('grad(u)_lastlast',ci)]=self.model.ebqe[('grad(u)_lastlast',ci)]
         if (self.densityModelIndex >= 0 and self.densityFunction is None):
             assert self.densityModelIndex < len(modelList), \
                 "density model index out of range 0," + repr(len(modelList))
@@ -528,45 +544,45 @@ class VelocityTransport2D(TransportCoefficients.TC_base):
                 self.c_rho[rho.shape] = rho
                 rho_last = self.densityModel.q[('u_last',0)]
                 self.c_rho_last[rho_last.shape] = rho_last
-                if self.useStabilityTerms:
-                    grad_rho = self.densityModel.q[('grad(u)',0)]
-                    self.c_rho[grad_rho.shape] = grad_rho
-                if self.bdf is int(2):
-                    rho_lastlast = self.densityModel.q[('u_lastlast',0)]
-                    self.c_rho_lastlast[rho_lastlast.shape] = rho_lastlast
+                # if self.useStabilityTerms:
+                grad_rho = self.densityModel.q[('grad(u)',0)]
+                self.c_rho[grad_rho.shape] = grad_rho
+                # if self.bdf is int(2):
+                rho_lastlast = self.densityModel.q[('u_lastlast',0)]
+                self.c_rho_lastlast[rho_lastlast.shape] = rho_lastlast
             if ('u',0) in self.densityModel.ebq:
                 rho = self.densityModel.ebq[('u',0)]
                 self.c_rho[rho.shape] = rho
                 rho_last = self.densityModel.ebq[('u_last',0)]
                 self.c_rho_last[rho_last.shape] = rho_last
-                if self.useStabilityTerms:
-                    grad_rho = self.densityModel.ebq[('grad(u)',0)]
-                    self.c_rho[grad_rho.shape] = grad_rho
-                if self.bdf is int(2):
-                    rho_lastlast = self.densityModel.ebq[('u_lastlast',0)]
-                    self.c_rho_lastlast[rho_lastlast.shape] = rho_lastlast
+                # if self.useStabilityTerms:
+                grad_rho = self.densityModel.ebq[('grad(u)',0)]
+                self.c_rho[grad_rho.shape] = grad_rho
+                # if self.bdf is int(2):
+                rho_lastlast = self.densityModel.ebq[('u_lastlast',0)]
+                self.c_rho_lastlast[rho_lastlast.shape] = rho_lastlast
             if ('u',0) in self.densityModel.ebqe:
                 rho = self.densityModel.ebqe[('u',0)]
                 self.c_rho[rho.shape] = rho
                 rho_last = self.densityModel.ebqe[('u_last',0)]
                 self.c_rho_last[rho_last.shape] = rho_last
-                if self.useStabilityTerms:
-                    grad_rho = self.densityModel.ebqe[('grad(u)',0)]
-                    self.c_rho[grad_rho.shape] = grad_rho
-                if self.bdf is int(2):
-                    rho_lastlast = self.densityModel.ebqe[('u_lastlast',0)]
-                    self.c_rho_lastlast[rho_lastlast.shape] = rho_lastlast
+                # if self.useStabilityTerms:
+                grad_rho = self.densityModel.ebqe[('grad(u)',0)]
+                self.c_rho[grad_rho.shape] = grad_rho
+                # if self.bdf is int(2):
+                rho_lastlast = self.densityModel.ebqe[('u_lastlast',0)]
+                self.c_rho_lastlast[rho_lastlast.shape] = rho_lastlast
             if ('u',0) in self.densityModel.ebq_global:
                 rho = self.densityModel.ebq_global[('u',0)]
                 self.c_rho[rho.shape] = rho
                 rho_last = self.densityModel.ebq_global[('u_last',0)]
                 self.c_rho_last[rho_last.shape] = rho_last
-                if self.useStabilityTerms:
-                    grad_rho = self.densityModel.ebq_global[('grad(u)',0)]
-                    self.c_rho[grad_rho.shape] = grad_rho
-                if self.bdf is int(2):
-                    rho_lastlast = self.densityModel.ebq_global[('u_lastlast',0)]
-                    self.c_rho_lastlast[rho_lastlast.shape] = rho_lastlast
+                # if self.useStabilityTerms:
+                grad_rho = self.densityModel.ebq_global[('grad(u)',0)]
+                self.c_rho[grad_rho.shape] = grad_rho
+                # if self.bdf is int(2):
+                rho_lastlast = self.densityModel.ebq_global[('u_lastlast',0)]
+                self.c_rho_lastlast[rho_lastlast.shape] = rho_lastlast
         if (self.pressureIncrementModelIndex >= 0 and self.pressureIncrementGradFunction is None):
             assert self.pressureIncrementModelIndex < len(modelList), \
                 "pressure increment model index out of range 0," + repr(len(modelList))
@@ -574,27 +590,27 @@ class VelocityTransport2D(TransportCoefficients.TC_base):
             if ('u',0) in self.pressureIncrementModel.q:
                 grad_phi_last = self.pressureIncrementModel.q[('grad(u)',0)]  #grad(u) here is at time t^{k} so is _last now
                 self.c_phi_last[grad_phi_last.shape] = grad_phi_last
-                if self.bdf is int(2):
-                    grad_phi_lastlast = self.pressureIncrementModel.q[('grad(u)_last',0)]  # grad(u)_last here is at time t^{k-1} so is _lastlast now
-                    self.c_phi_lastlast[grad_phi_lastlast.shape] = grad_phi_lastlast
+                # if self.bdf is int(2):
+                grad_phi_lastlast = self.pressureIncrementModel.q[('grad(u)_last',0)]  # grad(u)_last here is at time t^{k-1} so is _lastlast now
+                self.c_phi_lastlast[grad_phi_lastlast.shape] = grad_phi_lastlast
             if ('u',0) in self.pressureIncrementModel.ebq:
                 grad_phi_last = self.pressureIncrementModel.ebq[('grad(u)',0)]
                 self.c_phi_last[grad_phi_last.shape] = grad_phi_last
-                if self.bdf is int(2):
-                    grad_phi_lastlast = self.pressureIncrementModel.ebq[('grad(u)_last',0)]
-                    self.c_phi_lastlast[grad_phi_lastlast.shape] = grad_phi_lastlast
+                # if self.bdf is int(2):
+                grad_phi_lastlast = self.pressureIncrementModel.ebq[('grad(u)_last',0)]
+                self.c_phi_lastlast[grad_phi_lastlast.shape] = grad_phi_lastlast
             if ('u',0) in self.pressureIncrementModel.ebqe:
                 grad_phi_last = self.pressureIncrementModel.ebqe[('grad(u)',0)]
                 self.c_phi_last[grad_phi_last.shape] = grad_phi_last
-                if self.bdf is int(2):
-                    grad_phi_lastlast = self.pressureIncrementModel.ebqe[('grad(u)_last',0)]
-                    self.c_phi_lastlast[grad_phi_lastlast.shape] = grad_phi_lastlast
+                # if self.bdf is int(2):
+                grad_phi_lastlast = self.pressureIncrementModel.ebqe[('grad(u)_last',0)]
+                self.c_phi_lastlast[grad_phi_lastlast.shape] = grad_phi_lastlast
             if ('u',0) in self.pressureIncrementModel.ebq_global:
                 grad_phi_last = self.pressureIncrementModel.ebq_global[('grad(u)',0)]
                 self.c_phi_last[grad_phi_last.shape] = grad_phi_last
-                if self.bdf is int(2):
-                    grad_phi_lastlast = self.pressureIncrementModel.ebq_global[('grad(u)_last',0)]
-                    self.c_phi_lastlast[grad_phi_lastlast.shape] = grad_phi_lastlast
+                # if self.bdf is int(2):
+                grad_phi_lastlast = self.pressureIncrementModel.ebq_global[('grad(u)_last',0)]
+                self.c_phi_lastlast[grad_phi_lastlast.shape] = grad_phi_lastlast
         if (self.pressureModelIndex >= 0 and self.pressureGradFunction is None):
             assert self.pressureModelIndex < len(modelList), \
                 "pressure model index out of range 0," + repr(len(modelList))
@@ -602,27 +618,27 @@ class VelocityTransport2D(TransportCoefficients.TC_base):
             if ('u',0) in self.pressureModel.q:
                 grad_p_last = self.pressureModel.q[('grad(u)',0)] #grad(u) here is at time t^{k} so is _last in this context
                 self.c_p_last[grad_p_last.shape] = grad_p_last
-                if self.bdf is int(2):
-                    grad_p_lastlast = self.pressureModel.q[('grad(u)_last',0)]
-                    self.c_p_lastlast[grad_p_lastlast.shape] = grad_p_lastlast
+                # if self.bdf is int(2):
+                grad_p_lastlast = self.pressureModel.q[('grad(u)_last',0)]
+                self.c_p_lastlast[grad_p_lastlast.shape] = grad_p_lastlast
             if ('u',0) in self.pressureModel.ebq:
                 grad_p_last = self.pressureModel.ebq[('grad(u)',0)]
                 self.c_p_last[grad_p_last.shape] = grad_p_last
-                if self.bdf is int(2):
-                    grad_p_lastlast = self.pressureModel.ebq[('grad(u)_last',0)]
-                    self.c_p_lastlast[grad_p_lastlast.shape] = grad_p_lastlast
+                # if self.bdf is int(2):
+                grad_p_lastlast = self.pressureModel.ebq[('grad(u)_last',0)]
+                self.c_p_lastlast[grad_p_lastlast.shape] = grad_p_lastlast
             if ('u',0) in self.pressureModel.ebqe:
                 grad_p_last = self.pressureModel.ebqe[('grad(u)',0)]
                 self.c_p_last[grad_p_last.shape] = grad_p_last
-                if self.bdf is int(2):
-                    grad_p_lastlast = self.pressureModel.ebqe[('grad(u)_last',0)]
-                    self.c_p_lastlast[grad_p_lastlast.shape] = grad_p_lastlast
+                # if self.bdf is int(2):
+                grad_p_lastlast = self.pressureModel.ebqe[('grad(u)_last',0)]
+                self.c_p_lastlast[grad_p_lastlast.shape] = grad_p_lastlast
             if ('u',0) in self.pressureModel.ebq_global:
                 grad_p_last = self.pressureModel.ebq_global[('grad(u)',0)]
                 self.c_p_last[grad_p_last.shape] = grad_p_last
-                if self.bdf is int(2):
-                    grad_p_lastlast = self.pressureModel.ebq_global[('grad(u)_last',0)]
-                    self.c_p_lastlast[grad_p_lastlast.shape] = grad_p_lastlast
+                # if self.bdf is int(2):
+                grad_p_lastlast = self.pressureModel.ebq_global[('grad(u)_last',0)]
+                self.c_p_lastlast[grad_p_lastlast.shape] = grad_p_lastlast
     def initializeMesh(self,mesh):
         """
         Give the TC object access to the mesh for any mesh-dependent information.
@@ -635,9 +651,9 @@ class VelocityTransport2D(TransportCoefficients.TC_base):
         for ci in range(self.nc):
             cq[('u_last',ci)] = deepcopy(cq[('u',ci)])
             cq[('grad(u)_last',ci)] = deepcopy(cq[('grad(u)',ci)])
-            if self.bdf is int(2):
-                cq[('u_lastlast',ci)] = deepcopy(cq[('u',ci)])
-                cq[('grad(u)_lastlast',ci)] = deepcopy(cq[('grad(u)',ci)])
+            # if self.bdf is int(2):
+            cq[('u_lastlast',ci)] = deepcopy(cq[('u',ci)])
+            cq[('grad(u)_lastlast',ci)] = deepcopy(cq[('grad(u)',ci)])
 
     def initializeElementBoundaryQuadrature(self,t,cebq,cebq_global):
         """
@@ -656,9 +672,9 @@ class VelocityTransport2D(TransportCoefficients.TC_base):
         for ci in range(self.nc):
             cebqe[('u_last',ci)] = deepcopy(cebqe[('u',ci)])
             cebqe[('grad(u)_last',ci)] = deepcopy(cebqe[('grad(u)',ci)])
-            if self.bdf is int(2):
-                cebqe[('u_lastlast',ci)] = deepcopy(cebqe[('u',ci)])
-                cebqe[('grad(u)_lastlast',ci)] = deepcopy(cebqe[('grad(u)',ci)])
+            # if self.bdf is int(2):
+            cebqe[('u_lastlast',ci)] = deepcopy(cebqe[('u',ci)])
+            cebqe[('grad(u)_lastlast',ci)] = deepcopy(cebqe[('grad(u)',ci)])
     def initializeGeneralizedInterpolationPointQuadrature(self,t,cip):
         """
         Give the TC object access to the generalized interpolation point storage. These points are used  to project nonlinear potentials (phi).
@@ -698,11 +714,18 @@ class VelocityTransport2D(TransportCoefficients.TC_base):
         return copyInstructions
     def postStep(self,t,firstStep=False):
         """
-        Give the TC object an opportunity to modify itself after the time step.
+        Give the TC object an opportunity to modify itself before the time step.
         """
-        pass
-        # copyInstructions = {}
-        # return copyInstructions
+        if (firstStep and t>0):
+            self.model.q[('u',0)][:] = self.uFunction(self.model.q['x'],t)
+            self.model.q[('u',1)][:] = self.vFunction(self.model.q['x'],t)
+            self.model.ebqe[('u',0)] = self.uFunction(self.model.ebqe['x'],t)
+            self.model.ebqe[('u',1)] = self.vFunction(self.model.ebqe['x'],t)
+            self.model.u[0].dof[:] = self.uFunction(self.model.mesh.nodeArray,t)
+            self.model.u[1].dof[:] = self.vFunction(self.model.mesh.nodeArray,t)
+
+        copyInstructions = {}
+        return copyInstructions
     def evaluate(self,t,c):
         """
         evaluate quadrature point values held in the dictionary c
@@ -930,10 +953,10 @@ class PressureIncrement2D(TransportCoefficients.TC_base):
         # representing times t^{k} and t^{k-1} respectively.  Since velocity is before
         # pressure increment, we haven't had a chance to move the phi's to be consistent
         # notation on the new time step so we must handle this inconsistency here.
-        if self.bdf is int(2):
-            self.model.vectors_quadrature.add(('grad(u)_last',0))
-            self.model.vectors_elementBoundaryQuadrature.add(('grad(u)_last',0))
-            self.model.numericalFlux.ebqe[('grad(u)_last',0)] = self.model.ebqe[('grad(u)_last',0)]
+        # if self.bdf is int(2):
+        self.model.vectors_quadrature.add(('grad(u)_last',0))
+        self.model.vectors_elementBoundaryQuadrature.add(('grad(u)_last',0))
+        self.model.numericalFlux.ebqe[('grad(u)_last',0)] = self.model.ebqe[('grad(u)_last',0)]
         if (self.velocityModelIndex >= 0 and self.velocityFunction is None):
             assert self.velocityModelIndex < len(modelList), \
                 "velocity model index out of  range 0," + repr(len(modelList))
@@ -983,10 +1006,10 @@ class PressureIncrement2D(TransportCoefficients.TC_base):
         """
         Give the TC object access to the element quadrature storage
         """
-        if self.bdf is int(2):
-            for ci in range(self.nc):
-                # cq[('u_last',ci)] = deepcopy(cq[('u',ci)])
-                cq[('grad(u)_last',ci)] = deepcopy(cq[('grad(u)',ci)])
+        # if self.bdf is int(2):
+        for ci in range(self.nc):
+            # cq[('u_last',ci)] = deepcopy(cq[('u',ci)])
+            cq[('grad(u)_last',ci)] = deepcopy(cq[('grad(u)',ci)])
 
     def initializeElementBoundaryQuadrature(self,t,cebq,cebq_global):
         """
@@ -1003,10 +1026,10 @@ class PressureIncrement2D(TransportCoefficients.TC_base):
         """
         Give the TC object access to the exterior element boundary quadrature storage
         """
-        if self.bdf is int(2):
-            for ci in range(self.nc):
-                # cebqe[('u_last',ci)] = deepcopy(cebqe[('u',ci)])
-                cebqe[('grad(u)_last',ci)] = deepcopy(cebqe[('grad(u)',ci)])
+        # if self.bdf is int(2):
+        for ci in range(self.nc):
+            # cebqe[('u_last',ci)] = deepcopy(cebqe[('u',ci)])
+            cebqe[('grad(u)_last',ci)] = deepcopy(cebqe[('grad(u)',ci)])
 
 
     def initializeGeneralizedInterpolationPointQuadrature(self,t,cip):
@@ -1054,13 +1077,13 @@ class PressureIncrement2D(TransportCoefficients.TC_base):
             meanvalue = Norms.scalarDomainIntegral(self.model.q['dV'],
                                                    self.model.q[('u',0)],
                                                    self.model.mesh.nElements_owned)/self.model.mesh.volume
-            self.model.q[('u',0)][:] = self.model.q[('u',0)] - meanvalue
+            self.model.q[('u',0)][:] -= meanvalue
             self.model.ebqe[('u',0)] -= meanvalue
             self.model.u[0].dof -= meanvalue
 
             newmeanvalue = Norms.scalarDomainIntegral(self.model.q['dV'],
                                                       self.model.q[('u',0)],
-                                                      self.model.mesh.nElements_owned)
+                                                      self.model.mesh.nElements_owned)/self.model.mesh.volume
             assert fabs(newmeanvalue) < 1.0e-8, "new mean should be zero but is "+`newmeanvalue`
         # add post processing adjustments here if possible.  They have already be solved for by this point.
 
@@ -1146,6 +1169,7 @@ class Pressure2D(TransportCoefficients.TC_base):
                  useVelocityComponents=True,
                  pressureIncrementModelIndex=-1,
                  pressureIncrementFunction=None,
+                 pressureFunction=None,
                  useRotationalModel=True,
                  chiValue=1.0):
         """Construct a coefficients object
@@ -1178,6 +1202,7 @@ class Pressure2D(TransportCoefficients.TC_base):
         self.useVelocityComponents = useVelocityComponents
         self.pressureIncrementModelIndex = pressureIncrementModelIndex
         self.pressureIncrementFunction = pressureIncrementFunction
+        self.pressureFunction = pressureFunction
         self.useRotationalModel = useRotationalModel
         self.chiValue = chiValue
         if self.useRotationalModel:
@@ -1329,6 +1354,17 @@ class Pressure2D(TransportCoefficients.TC_base):
             # when we do need grad_pressure^k, we are on velocity model on the next time
             # step so that 'grad(u)' is grad_pressure^k.
 
+
+        copyInstructions = {}
+        return copyInstructions
+    def postStep(self,t,firstStep=False):
+        """
+        Give the TC object an opportunity to modify itself before the time step.
+        """
+        if (firstStep and t>0):
+            self.model.q[('u',0)][:] = self.pressureFunction(self.model.q['x'],t)
+            self.model.ebqe[('u',0)] = self.pressureFunction(self.model.ebqe['x'],t)
+            self.model.u[0].dof[:] = self.pressureFunction(self.model.mesh.nodeArray,t)
 
         copyInstructions = {}
         return copyInstructions

--- a/NavierStokesNotebooks/VariableDensityNavierStokes2D/NavierStokesVariableDensity.py
+++ b/NavierStokesNotebooks/VariableDensityNavierStokes2D/NavierStokesVariableDensity.py
@@ -651,9 +651,9 @@ class VelocityTransport2D(TransportCoefficients.TC_base):
         div_vel_lastlast = grad_u_lastlast[...,xi] + grad_v_lastlast[...,yi]
 
 
-        rho_sharp        = rho # rho
+        rho_sharp        = rho
         rho_t            = (rho - rho_last)/dt #b0*rho - b1*rho_last - b2*rho_lastlast
-        grad_p_sharp     = grad_p_last + b1/b0 * grad_phi_last + b2/b0 * grad_phi_lastlast #grad_p_last + grad_phi_last 
+        grad_p_sharp     = grad_p_last + b1/b0 * grad_phi_last + b2/b0 * grad_phi_lastlast #grad_p_last + grad_phi_last
         div_vel_star     = div_vel_last #+ dt/dt_last*( div_vel_last - div_vel_lastlast)
         u_star           = u_last #+ dt/dt_last*( u_last - u_lastlast )
         v_star           = v_last #+ dt/dt_last*( v_last - v_lastlast )
@@ -873,7 +873,7 @@ class PressureIncrement2D(TransportCoefficients.TC_base):
             meanvalue = Norms.scalarDomainIntegral(self.model.q['dV'],
                                                    self.model.q[('u',0)],
                                                    self.model.mesh.nElements_owned)/self.model.mesh.volume
-            self.model.q[('u',0)][:] = self.model.q[('u',0)] - meanvalue
+            self.model.q[('u',0)] -= meanvalue
             self.model.ebqe[('u',0)] -= meanvalue
             self.model.u[0].dof -= meanvalue
 
@@ -904,13 +904,12 @@ class PressureIncrement2D(TransportCoefficients.TC_base):
 
         # time management
         dt = self.model.timeIntegration.dt
+        # dt_last = self.velocityModel.timeIntegration.dt_history[0] # velocity model has the timeIntegration all set up.
         dt_last = dt
-
-        # b0 = 1.0/dt
         dtInv = 1.0/dt
         r = dt/dt_last
-        b0 = (1.0+2.0*r)/(1.0+r)*dtInv   # is self.model.timeIntegration.alpha_bdf as set in calculateCoefs() of timeIntegration.py
-        # b0 = self.model.timeIntegration.alpha_bdf  # = beta_0
+        # b0 = 1.0/dt
+        b0 = (1.0+2.0*r)/(1.0+r)*dtInv # use this instead of alpha_bdf since we have no timeIntegration in this model
 
         chi = self.chiValue
 

--- a/NavierStokesNotebooks/VariableDensityNavierStokes2D/NavierStokesVariableDensity.py
+++ b/NavierStokesNotebooks/VariableDensityNavierStokes2D/NavierStokesVariableDensity.py
@@ -265,15 +265,21 @@ class DensityTransport2D(TransportCoefficients.TC_base):
         rho = c[('u',0)]
 
         dt = self.model.timeIntegration.dt
-        tLast = self.model.timeIntegration.tLast
+        # dt_last = self.model.timeIntegration.dt_history[0] # note this only exists if we are using VBDF for Time integration
+        # if self.firstStep:
+        dt_last = dt
 
         u_last = self.c_u_last[c[('m',0)].shape]
         v_last = self.c_v_last[c[('m',0)].shape]
-        div_vel_last = self.c_grad_u_last[c[('f',0)].shape][...,0] + self.c_grad_v_last[c[('f',0)].shape][...,1]
+        u_lastlast = self.c_u_lastlast[c[('m',0)].shape]
+        v_lastlast = self.c_v_lastlast[c[('m',0)].shape]
 
-        u_star = u_last
-        v_star = v_last
-        div_vel_star = div_vel_last
+        div_vel_last = self.c_grad_u_last[c[('f',0)].shape][...,0] + self.c_grad_v_last[c[('f',0)].shape][...,1]
+        div_vel_lastlast = self.c_grad_u_lastlast[c[('f',0)].shape][...,0] + self.c_grad_v_lastlast[c[('f',0)].shape][...,1]
+
+        u_star = u_last + dt/dt_last*( u_last - u_lastlast )
+        v_star = v_last + dt/dt_last*( v_last - v_lastlast )
+        div_vel_star = div_vel_last + dt/dt_last*(div_vel_last - div_vel_lastlast )
 
         #  rho_t + div( rho vel_star) - 0.5 rho div( vel_star ) = 0
         c[('m',0)][:] = rho

--- a/NavierStokesNotebooks/VariableDensityNavierStokes2D/density_n.py
+++ b/NavierStokesNotebooks/VariableDensityNavierStokes2D/density_n.py
@@ -11,7 +11,7 @@ femSpaces = {0:FemTools.C0_AffineQuadraticOnSimplexWithNodalBasis} # density spa
 # timeIntegration = TimeIntegration.BackwardEuler
 # timeIntegration = TimeIntegration.BackwardEuler_cfl
 # timeIntegration = TimeIntegration.VBDF
-timeOrder = ctx.globalBDFTimeOrder
+timeOrder = 2 #ctx.globalBDFTimeOrder
 
 if timeOrder == 1:
     timeIntegration = TimeIntegration.BackwardEuler

--- a/NavierStokesNotebooks/VariableDensityNavierStokes2D/density_n.py
+++ b/NavierStokesNotebooks/VariableDensityNavierStokes2D/density_n.py
@@ -12,14 +12,15 @@ femSpaces = {0:FemTools.C0_AffineQuadraticOnSimplexWithNodalBasis} # density spa
 # timeIntegration = TimeIntegration.BackwardEuler_cfl
 # timeIntegration = TimeIntegration.VBDF
 timeOrder = ctx.globalBDFTimeOrder
+timeIntegration = TimeIntegration.VBDF
 
-if timeOrder == 1:
-    timeIntegration = TimeIntegration.BackwardEuler
-    # timeIntegration = TimeIntegration.BackwardEuler_cfl
-elif timeOrder == 2:
-    timeIntegration = TimeIntegration.VBDF
-else:
-    assert False, "BDF order %d for time integration is not supported." % timeOrder
+# if timeOrder == 1:
+#     timeIntegration = TimeIntegration.BackwardEuler
+#     # timeIntegration = TimeIntegration.BackwardEuler_cfl
+# elif timeOrder == 2:
+#     timeIntegration = TimeIntegration.VBDF
+# else:
+#     assert False, "BDF order %d for time integration is not supported." % timeOrder
 
 # stepController  = StepControl.Min_dt_cfl_controller
 # runCFL= 0.99

--- a/NavierStokesNotebooks/VariableDensityNavierStokes2D/density_n.py
+++ b/NavierStokesNotebooks/VariableDensityNavierStokes2D/density_n.py
@@ -11,7 +11,7 @@ femSpaces = {0:FemTools.C0_AffineQuadraticOnSimplexWithNodalBasis} # density spa
 # timeIntegration = TimeIntegration.BackwardEuler
 # timeIntegration = TimeIntegration.BackwardEuler_cfl
 # timeIntegration = TimeIntegration.VBDF
-timeOrder = 2 #ctx.globalBDFTimeOrder
+timeOrder = ctx.globalBDFTimeOrder
 
 if timeOrder == 1:
     timeIntegration = TimeIntegration.BackwardEuler

--- a/NavierStokesNotebooks/VariableDensityNavierStokes2D/density_p.py
+++ b/NavierStokesNotebooks/VariableDensityNavierStokes2D/density_p.py
@@ -17,7 +17,8 @@ coefficients=NavierStokes.DensityTransport2D(chiValue=ctx.chi,
                                              densityFunction=ctx.rhotrue,
                                              velocityModelIndex=1,  #don't change this unless the order in so-file is changed
                                              pressureIncrementModelIndex=2,
-                                             useStabilityTerms=ctx.useStabilityTerms)
+                                             useStabilityTerms=ctx.useStabilityTerms,
+                                             setFirstTimeStepValues = ctx.setFirstTimeStepValues)
 
 if ctx.opts.analytical:
    analyticalSolution = {0:ctx.AnalyticSolutionConverter(ctx.rhotrue)}

--- a/NavierStokesNotebooks/VariableDensityNavierStokes2D/density_p.py
+++ b/NavierStokesNotebooks/VariableDensityNavierStokes2D/density_p.py
@@ -12,16 +12,11 @@ name = "density"
 
 
 # from pnList in *_so.py  0 = density,  1 = (u,v), 2 = (pressureincrement),  3 = (pressure)
-coefficients=NavierStokes.DensityTransport2D(bdf=ctx.globalBDFTimeOrder,
-                                             chiValue=ctx.chi,
+coefficients=NavierStokes.DensityTransport2D(chiValue=ctx.chi,
                                              currentModelIndex=0,
                                              densityFunction=ctx.rhotrue,
                                              velocityModelIndex=1,  #don't change this unless the order in so-file is changed
-                                             velocityFunction=None, #or ctx.velocityFunction to use exact solution (uncoupled transport)
-                                             divVelocityFunction=None, # or ctx.divVelocityFunction to use exact divergence solution
-                                             useVelocityComponents=ctx.useVelocityComponents, #set to false to use 'velocity' (possible post-processed)
                                              pressureIncrementModelIndex=2,
-                                             pressureIncrementFunction=None,  # or ctx.pitrue
                                              useStabilityTerms=False)#ctx.useStabilityTerms)
 
 if ctx.opts.analytical:

--- a/NavierStokesNotebooks/VariableDensityNavierStokes2D/density_p.py
+++ b/NavierStokesNotebooks/VariableDensityNavierStokes2D/density_p.py
@@ -17,7 +17,7 @@ coefficients=NavierStokes.DensityTransport2D(chiValue=ctx.chi,
                                              densityFunction=ctx.rhotrue,
                                              velocityModelIndex=1,  #don't change this unless the order in so-file is changed
                                              pressureIncrementModelIndex=2,
-                                             useStabilityTerms=False)#ctx.useStabilityTerms)
+                                             useStabilityTerms=ctx.useStabilityTerms)
 
 if ctx.opts.analytical:
    analyticalSolution = {0:ctx.AnalyticSolutionConverter(ctx.rhotrue)}

--- a/NavierStokesNotebooks/VariableDensityNavierStokes2D/density_p.py
+++ b/NavierStokesNotebooks/VariableDensityNavierStokes2D/density_p.py
@@ -15,6 +15,7 @@ name = "density"
 coefficients=NavierStokes.DensityTransport2D(bdf=ctx.globalBDFTimeOrder,
                                              chiValue=ctx.chi,
                                              currentModelIndex=0,
+                                             densityFunction=ctx.rhotrue,
                                              velocityModelIndex=1,  #don't change this unless the order in so-file is changed
                                              velocityFunction=None, #or ctx.velocityFunction to use exact solution (uncoupled transport)
                                              divVelocityFunction=None, # or ctx.divVelocityFunction to use exact divergence solution

--- a/NavierStokesNotebooks/VariableDensityNavierStokes2D/density_p.py
+++ b/NavierStokesNotebooks/VariableDensityNavierStokes2D/density_p.py
@@ -15,6 +15,8 @@ name = "density"
 coefficients=NavierStokes.DensityTransport2D(currentModelIndex=0,
                                              densityFunction=ctx.rhotrue,
                                              velocityModelIndex=1,  #don't change this unless the order in so-file is changed
+                                             uFunction=None,#ctx.utrue,
+                                             vFunction=None,#ctx.vtrue,
                                              pressureIncrementModelIndex=2,
                                              useStabilityTerms=ctx.useStabilityTerms,
                                              setFirstTimeStepValues = ctx.setFirstTimeStepValues)

--- a/NavierStokesNotebooks/VariableDensityNavierStokes2D/density_p.py
+++ b/NavierStokesNotebooks/VariableDensityNavierStokes2D/density_p.py
@@ -12,8 +12,7 @@ name = "density"
 
 
 # from pnList in *_so.py  0 = density,  1 = (u,v), 2 = (pressureincrement),  3 = (pressure)
-coefficients=NavierStokes.DensityTransport2D(chiValue=ctx.chi,
-                                             currentModelIndex=0,
+coefficients=NavierStokes.DensityTransport2D(currentModelIndex=0,
                                              densityFunction=ctx.rhotrue,
                                              velocityModelIndex=1,  #don't change this unless the order in so-file is changed
                                              pressureIncrementModelIndex=2,

--- a/NavierStokesNotebooks/VariableDensityNavierStokes2D/navierstokes_vardensity.py
+++ b/NavierStokesNotebooks/VariableDensityNavierStokes2D/navierstokes_vardensity.py
@@ -19,7 +19,7 @@ nd = 2
 quad_degree = 5  # exact for polynomials of this degree between [1 .. 5]
 
 # Model Flags
-useStabilityTerms = True  # stability terms in density and velocity models
+useStabilityTerms = False  # stability terms in density and velocity models
 globalBDFTimeOrder = 2 # 1 or 2 for time integration algorithms
 useDirichletPressureBC = False  # Dirichlet bc pressure or zeroMean pressure increment
 useRotationalModel = False #  Standard vs Rotational models in pressure update

--- a/NavierStokesNotebooks/VariableDensityNavierStokes2D/navierstokes_vardensity.py
+++ b/NavierStokesNotebooks/VariableDensityNavierStokes2D/navierstokes_vardensity.py
@@ -20,16 +20,14 @@ quad_degree = 5  # exact for polynomials of this degree
 
 # Model Flags
 useStabilityTerms = False  # stability terms in density and velocity models
-useVelocityComponents = True  # False uses post processed velocity,
 globalBDFTimeOrder = 2 # 1 or 2 for time integration algorithms
 useDirichletPressureBC = False  # Dirichlet bc pressure or zeroMean pressure increment
 useRotationalModel = False #  Standard vs Rotational models in pressure update
-initializePressureIncrementUsingPressureFunction = False # set firstStep value to be p_h^1- p_h^0
 useScaleUpTimeStepsBDF2 = False  # Time steps = [dt^2, 2dt^2, 4dt^2, ... dt, ... , dt, T-tLast]
 
 # setup time variables
 T = 1.0
-DT = 0.05  # target time step size
+DT = 0.1  # target time step size
 
 # setup tnList
 if globalBDFTimeOrder == 1 or not useScaleUpTimeStepsBDF2:
@@ -298,7 +296,7 @@ nLayersOfOverlapForParallel = 0
 
 # Time stepping for output
 # T=10.0
-# DT = 0.05
+# DT = 0.1
 # nFrames = 51
 # dt = T/(nFrames-1)
 # tnList = [0, DT] + [ i*dt for i in range(1,nFrames) ]

--- a/NavierStokesNotebooks/VariableDensityNavierStokes2D/navierstokes_vardensity.py
+++ b/NavierStokesNotebooks/VariableDensityNavierStokes2D/navierstokes_vardensity.py
@@ -20,7 +20,7 @@ quad_degree = 5  # exact for polynomials of this degree between [1 .. 5]
 
 # Model Flags
 useStabilityTerms = True  # stability terms in density and velocity models
-globalBDFTimeOrder = 1 # 1 or 2 for time integration algorithms
+globalBDFTimeOrder = 2 # 1 or 2 for time integration algorithms
 useDirichletPressureBC = False  # Dirichlet bc pressure or zeroMean pressure increment
 useRotationalModel = False #  Standard vs Rotational models in pressure update
 useScaleUpTimeStepsBDF2 = False  # Time steps = [dt^2, 2dt^2, 4dt^2, ... dt, ... , dt, T-tLast]
@@ -28,7 +28,7 @@ setFirstTimeStepValues = True #
 
 # setup time variables
 T = 1.0
-DT = 0.1  # target time step size
+DT = 0.05  # target time step size
 
 # setup tnList
 if globalBDFTimeOrder == 1 or not useScaleUpTimeStepsBDF2:
@@ -297,7 +297,7 @@ nLayersOfOverlapForParallel = 0
 
 # Time stepping for output
 # T=10.0
-# DT = 0.1
+# DT = 0.05
 # nFrames = 51
 # dt = T/(nFrames-1)
 # tnList = [0, DT] + [ i*dt for i in range(1,nFrames) ]

--- a/NavierStokesNotebooks/VariableDensityNavierStokes2D/navierstokes_vardensity.py
+++ b/NavierStokesNotebooks/VariableDensityNavierStokes2D/navierstokes_vardensity.py
@@ -28,7 +28,7 @@ setFirstTimeStepValues = True #
 
 # setup time variables
 T = 1.0
-DT = 0.05  # target time step size
+DT = 0.1  # target time step size
 
 # setup tnList
 if globalBDFTimeOrder == 1 or not useScaleUpTimeStepsBDF2:
@@ -297,7 +297,7 @@ nLayersOfOverlapForParallel = 0
 
 # Time stepping for output
 # T=10.0
-# DT = 0.05
+# DT = 0.1
 # nFrames = 51
 # dt = T/(nFrames-1)
 # tnList = [0, DT] + [ i*dt for i in range(1,nFrames) ]

--- a/NavierStokesNotebooks/VariableDensityNavierStokes2D/navierstokes_vardensity.py
+++ b/NavierStokesNotebooks/VariableDensityNavierStokes2D/navierstokes_vardensity.py
@@ -29,7 +29,7 @@ useScaleUpTimeStepsBDF2 = False  # Time steps = [dt^2, 2dt^2, 4dt^2, ... dt, ...
 
 # setup time variables
 T = 1.0
-DT = 0.1  # target time step size
+DT = 0.05  # target time step size
 
 # setup tnList
 if globalBDFTimeOrder == 1 or not useScaleUpTimeStepsBDF2:
@@ -87,7 +87,7 @@ xs,ys,ts = symbols('x y t')
 
 # viscosity coefficient
 mu = 1.0 # the viscosity coefficient
-chi = 0.8  # 1.0 is the minimal value of rho density.
+chi = 1.0  # 1.0 is the minimal value of rho density.
 
 # Given solution: (Modify here and if needed add more sympy.functions above with
 #                  notation sy_* to distinguish as symbolic functions)
@@ -298,7 +298,7 @@ nLayersOfOverlapForParallel = 0
 
 # Time stepping for output
 # T=10.0
-# DT = 0.1
+# DT = 0.05
 # nFrames = 51
 # dt = T/(nFrames-1)
 # tnList = [0, DT] + [ i*dt for i in range(1,nFrames) ]

--- a/NavierStokesNotebooks/VariableDensityNavierStokes2D/navierstokes_vardensity.py
+++ b/NavierStokesNotebooks/VariableDensityNavierStokes2D/navierstokes_vardensity.py
@@ -16,18 +16,19 @@ opts = Context.Options([
 nd = 2
 
 # Numerics
-quad_degree = 5  # exact for polynomials of this degree
+quad_degree = 5  # exact for polynomials of this degree between [1 .. 5]
 
 # Model Flags
-useStabilityTerms = False  # stability terms in density and velocity models
-globalBDFTimeOrder = 2 # 1 or 2 for time integration algorithms
+useStabilityTerms = True  # stability terms in density and velocity models
+globalBDFTimeOrder = 1 # 1 or 2 for time integration algorithms
 useDirichletPressureBC = False  # Dirichlet bc pressure or zeroMean pressure increment
 useRotationalModel = False #  Standard vs Rotational models in pressure update
 useScaleUpTimeStepsBDF2 = False  # Time steps = [dt^2, 2dt^2, 4dt^2, ... dt, ... , dt, T-tLast]
+setFirstTimeStepValues = False #
 
 # setup time variables
-T = 1.0
-DT = 0.1  # target time step size
+T = 0.125
+DT = 0.00625  # target time step size
 
 # setup tnList
 if globalBDFTimeOrder == 1 or not useScaleUpTimeStepsBDF2:
@@ -296,7 +297,7 @@ nLayersOfOverlapForParallel = 0
 
 # Time stepping for output
 # T=10.0
-# DT = 0.1
+# DT = 0.00625
 # nFrames = 51
 # dt = T/(nFrames-1)
 # tnList = [0, DT] + [ i*dt for i in range(1,nFrames) ]

--- a/NavierStokesNotebooks/VariableDensityNavierStokes2D/navierstokes_vardensity.py
+++ b/NavierStokesNotebooks/VariableDensityNavierStokes2D/navierstokes_vardensity.py
@@ -27,8 +27,8 @@ useScaleUpTimeStepsBDF2 = False  # Time steps = [dt^2, 2dt^2, 4dt^2, ... dt, ...
 setFirstTimeStepValues = False #
 
 # setup time variables
-T = 0.125
-DT = 0.00625  # target time step size
+T = 1.0
+DT = 0.1  # target time step size
 
 # setup tnList
 if globalBDFTimeOrder == 1 or not useScaleUpTimeStepsBDF2:
@@ -297,7 +297,7 @@ nLayersOfOverlapForParallel = 0
 
 # Time stepping for output
 # T=10.0
-# DT = 0.00625
+# DT = 0.1
 # nFrames = 51
 # dt = T/(nFrames-1)
 # tnList = [0, DT] + [ i*dt for i in range(1,nFrames) ]

--- a/NavierStokesNotebooks/VariableDensityNavierStokes2D/navierstokes_vardensity.py
+++ b/NavierStokesNotebooks/VariableDensityNavierStokes2D/navierstokes_vardensity.py
@@ -24,7 +24,7 @@ globalBDFTimeOrder = 1 # 1 or 2 for time integration algorithms
 useDirichletPressureBC = False  # Dirichlet bc pressure or zeroMean pressure increment
 useRotationalModel = False #  Standard vs Rotational models in pressure update
 useScaleUpTimeStepsBDF2 = False  # Time steps = [dt^2, 2dt^2, 4dt^2, ... dt, ... , dt, T-tLast]
-setFirstTimeStepValues = False #
+setFirstTimeStepValues = True #
 
 # setup time variables
 T = 1.0

--- a/NavierStokesNotebooks/VariableDensityNavierStokes2D/pressure_p.py
+++ b/NavierStokesNotebooks/VariableDensityNavierStokes2D/pressure_p.py
@@ -19,7 +19,8 @@ coefficients=NavierStokes.Pressure2D(mu=ctx.mu,
                                      pressureIncrementModelIndex=2,
                                      pressureFunction=ctx.ptrue,
                                      useRotationalModel=ctx.useRotationalModel,
-                                     currentModelIndex=3)
+                                     currentModelIndex=3,
+                                     setFirstTimeStepValues=ctx.setFirstTimeStepValues)
 
 if ctx.opts.analytical:
     analyticalSolution = {0:ctx.AnalyticSolutionConverter(ctx.ptrue,ctx.gradptrue)}

--- a/NavierStokesNotebooks/VariableDensityNavierStokes2D/pressure_p.py
+++ b/NavierStokesNotebooks/VariableDensityNavierStokes2D/pressure_p.py
@@ -14,7 +14,6 @@ name = "pressure"
 #the object for evaluating the coefficients
 # from pnList in *_so.py  0 = density,  1 = (u,v), 2 = (pressureincrement),  3 = (pressure)
 coefficients=NavierStokes.Pressure2D(mu=ctx.mu,
-                                     chiValue=ctx.chi,
                                      velocityModelIndex=1,
                                      pressureIncrementModelIndex=2,
                                      pressureFunction=ctx.ptrue,

--- a/NavierStokesNotebooks/VariableDensityNavierStokes2D/pressure_p.py
+++ b/NavierStokesNotebooks/VariableDensityNavierStokes2D/pressure_p.py
@@ -13,14 +13,10 @@ name = "pressure"
 
 #the object for evaluating the coefficients
 # from pnList in *_so.py  0 = density,  1 = (u,v), 2 = (pressureincrement),  3 = (pressure)
-coefficients=NavierStokes.Pressure2D(bdf=ctx.globalBDFTimeOrder,
-                                     mu=ctx.mu,
+coefficients=NavierStokes.Pressure2D(mu=ctx.mu,
                                      chiValue=ctx.chi,
                                      velocityModelIndex=1,
-                                     velocityFunction=None, # use ctx.velocityFunction for exact velocity
-                                     useVelocityComponents=ctx.useVelocityComponents,
                                      pressureIncrementModelIndex=2,
-                                     pressureIncrementFunction=None,  # use ctx.gradpitrue for exact pressure increment (=0)
                                      pressureFunction=ctx.ptrue,
                                      useRotationalModel=ctx.useRotationalModel,
                                      currentModelIndex=3)

--- a/NavierStokesNotebooks/VariableDensityNavierStokes2D/pressure_p.py
+++ b/NavierStokesNotebooks/VariableDensityNavierStokes2D/pressure_p.py
@@ -21,6 +21,7 @@ coefficients=NavierStokes.Pressure2D(bdf=ctx.globalBDFTimeOrder,
                                      useVelocityComponents=ctx.useVelocityComponents,
                                      pressureIncrementModelIndex=2,
                                      pressureIncrementFunction=None,  # use ctx.gradpitrue for exact pressure increment (=0)
+                                     pressureFunction=ctx.ptrue,
                                      useRotationalModel=ctx.useRotationalModel,
                                      currentModelIndex=3)
 

--- a/NavierStokesNotebooks/VariableDensityNavierStokes2D/pressureincrement_p.py
+++ b/NavierStokesNotebooks/VariableDensityNavierStokes2D/pressureincrement_p.py
@@ -18,7 +18,8 @@ coefficients=NavierStokes.PressureIncrement2D(chiValue=ctx.chi,
                                               densityModelIndex=0,
                                               velocityModelIndex=1,
                                               pressureFunction=ctx.ptrue,
-                                              currentModelIndex=2)
+                                              currentModelIndex=2,
+                                              setFirstTimeStepValues=ctx.setFirstTimeStepValues)
 
 if ctx.opts.analytical:
     analyticalSolution = {0:ctx.AnalyticSolutionConverter(ctx.pitrue,ctx.gradpitrue)}

--- a/NavierStokesNotebooks/VariableDensityNavierStokes2D/pressureincrement_p.py
+++ b/NavierStokesNotebooks/VariableDensityNavierStokes2D/pressureincrement_p.py
@@ -13,14 +13,11 @@ name = "pressureincrement"
 #the object for evaluating the coefficients
 
 # from pnList in *_so.py  0 = density,  1 = (u,v),  2 = (pressureincrement),  3 = (pressure)
-coefficients=NavierStokes.PressureIncrement2D(bdf=ctx.globalBDFTimeOrder,
-                                              chiValue=ctx.chi,
+coefficients=NavierStokes.PressureIncrement2D(chiValue=ctx.chi,
                                               zeroMean=not ctx.useDirichletPressureBC,
                                               densityModelIndex=0,
                                               velocityModelIndex=1,
-                                              velocityFunction=None, # use ctx.velocityFunction for exact velocity
                                               pressureFunction=ctx.ptrue,
-                                              initializeUsingPressureFunction=ctx.initializePressureIncrementUsingPressureFunction,
                                               currentModelIndex=2)
 
 if ctx.opts.analytical:

--- a/NavierStokesNotebooks/VariableDensityNavierStokes2D/velocity_n.py
+++ b/NavierStokesNotebooks/VariableDensityNavierStokes2D/velocity_n.py
@@ -12,12 +12,14 @@ femSpaces = {0:FemTools.C0_AffineQuadraticOnSimplexWithNodalBasis, # u velocity 
 timeOrder = ctx.globalBDFTimeOrder
 
 from TimeIntegrationPS import NonConservativeBackwardEuler, NonConservativeVBDF
-if timeOrder == 1:
-    timeIntegration = NonConservativeBackwardEuler
-elif timeOrder == 2:
-    timeIntegration = NonConservativeVBDF
-else:
-    assert False, "BDF order %d for time integration is not supported." % timeOrder
+timeIntegration = NonConservativeVBDF
+
+# if timeOrder == 1:
+#     timeIntegration = NonConservativeBackwardEuler
+# elif timeOrder == 2:
+#     timeIntegration = NonConservativeVBDF
+# else:
+#     assert False, "BDF order %d for time integration is not supported." % timeOrder
 
 
 # stepController  = StepControl.Min_dt_cfl_controller

--- a/NavierStokesNotebooks/VariableDensityNavierStokes2D/velocity_p.py
+++ b/NavierStokesNotebooks/VariableDensityNavierStokes2D/velocity_p.py
@@ -22,7 +22,8 @@ coefficients=NavierStokes.VelocityTransport2D(f1ofx=ctx.f1true,
                                               vFunction=ctx.vtrue,
                                               pressureIncrementModelIndex=2,
                                               pressureModelIndex=3,
-                                              useStabilityTerms=ctx.useStabilityTerms)
+                                              useStabilityTerms=ctx.useStabilityTerms,
+                                              setFirstTimeStepValues=ctx.setFirstTimeStepValues)
 
 if ctx.opts.analytical:
     analyticalSolution = {0:ctx.AnalyticSolutionConverter(ctx.utrue,ctx.gradutrue),

--- a/NavierStokesNotebooks/VariableDensityNavierStokes2D/velocity_p.py
+++ b/NavierStokesNotebooks/VariableDensityNavierStokes2D/velocity_p.py
@@ -21,6 +21,8 @@ coefficients=NavierStokes.VelocityTransport2D(bdf=ctx.globalBDFTimeOrder,
                                               densityFunction=None, #set to ctx.rhotrue for exact density (uncoupled  flow)
                                               densityGradFunction=None,  #set to ctx.gradrhotrue for exact grad density
                                               currentModelIndex=1,
+                                              uFunction=ctx.utrue,
+                                              vFunction=ctx.vtrue,
                                               pressureIncrementModelIndex=2,
                                               pressureIncrementGradFunction=None, # set to ctx.gradpitrue for exact pressure increment
                                               pressureModelIndex=3,

--- a/NavierStokesNotebooks/VariableDensityNavierStokes2D/velocity_p.py
+++ b/NavierStokesNotebooks/VariableDensityNavierStokes2D/velocity_p.py
@@ -13,20 +13,15 @@ name = "velocity"
 #the object for evaluating the coefficients
 
 # from pnList in *_so.py  0 = density,  1 = (u,v), 2 = (pressureincrement),  3 = (pressure)
-coefficients=NavierStokes.VelocityTransport2D(bdf=ctx.globalBDFTimeOrder,
-                                              f1ofx=ctx.f1true,
+coefficients=NavierStokes.VelocityTransport2D(f1ofx=ctx.f1true,
                                               f2ofx=ctx.f2true,
                                               mu=ctx.mu,
                                               densityModelIndex=0,
-                                              densityFunction=None, #set to ctx.rhotrue for exact density (uncoupled  flow)
-                                              densityGradFunction=None,  #set to ctx.gradrhotrue for exact grad density
                                               currentModelIndex=1,
                                               uFunction=ctx.utrue,
                                               vFunction=ctx.vtrue,
                                               pressureIncrementModelIndex=2,
-                                              pressureIncrementGradFunction=None, # set to ctx.gradpitrue for exact pressure increment
                                               pressureModelIndex=3,
-                                              pressureGradFunction=None, # set to ctx.gradptrue for exact pressure
                                               useStabilityTerms=ctx.useStabilityTerms)
 
 if ctx.opts.analytical:


### PR DESCRIPTION
@cekees  @mfarthin This version is the latest from srobertp/testBDF2  where i have stripped away everything but the bdf2 algorithm at its simplest form(no given functions to substitute or post processed velocities).  Hopefully we can figure out what is causing the algorithm to not work here where all the fluff and bells and whistles are stripped away

I don't intend to actually merge this in but I wanted to start a conversation

We currently initialize the 0th step through initial conditions and the first step in the postStep() functions according to the earlier JCP paper.  We set rho, u v, p  at time t1  by interpolation  and phi_h^0 = 0,  phi_h^1 = p_h^1-p_h^0

When we turn off the rotational model, we get no convergence anywhere.  So I want to debug without the rotational model.  In this case the above initial conditions are correct (as long as our interpolation is O(h)  approximation)

I have tried varying the Velocity bc's between Strong dirichlet and weak dirichlet in the Numerical Flux with self.useStrongDirichletConstraints = True or False .  I see little to no effect.

I have verified that the three coefficients that we are calculating for the time derivatives are correctly being set.  

We currently have the density shock capturing tuned off completely but that doesn't seem to make any difference in the quality of solution of density at the moment.  Our density is pretty smooth in this example.  

We can turn the Stability Terms on or off.  In one paper he discusses using them in another he leaves them out.  When I vary this, I don't see much of a difference.  There is some and we see a little better error values with them turned on but not very large difference

0.015 < h < 0.045
max |velocity| <= 1

so CFL = c*(h/p) / (max |v|) with c = 1/3 gives
0.005 < CFL < 0.015
but tau =  0.1,  0.05,  0.025,  0.0125,  0.006125

so that we are only in the CFL regime for the last two (maybe not even any of them although h ave ~ 0.04 so that we are closer to the top region of the interval)

We are using exact for 5th order polynomials,  the scripts process*.py now contain two versions of the error calculations:  Adaptive time stepping (using number of time steps) and uniform time stepping(using max time step as dt)  They are exactly the same when we use uniform time stepping so that the adaptive version is generally preferred as an all purpose error calculation.  They both give the same results and the errors match with the output errors displayed in the log at each interval summary calculation.

Any thoughts?
