### PR TITLE
[2nd order in u,v] added timeIntegration calculation in postStep; implicit velocity

### DIFF
--- a/NavierStokesNotebooks/VariableDensityNavierStokes2D/NavierStokesVariableDensity.py
+++ b/NavierStokesNotebooks/VariableDensityNavierStokes2D/NavierStokesVariableDensity.py
@@ -327,6 +327,7 @@ class DensityTransport2D(TransportCoefficients.TC_base):
             # self.evaluate(t,self.model.ebq)
             self.evaluate(t,self.model.ebqe)
             # self.evaluate(t,self.model.ebq_global)
+            self.model.timeIntegration.calculateElementCoefficients(self.model.q)
 
         copyInstructions = {}
         return copyInstructions
@@ -741,7 +742,7 @@ class VelocityTransport2D(TransportCoefficients.TC_base):
             # self.evaluate(t,self.model.ebq)
             self.evaluate(t,self.model.ebqe)
             # self.evaluate(t,self.model.ebq_global)
-
+            self.model.timeIntegration.calculateElementCoefficients(self.model.q)
         copyInstructions = {}
         return copyInstructions
     def evaluate(self,t,c):
@@ -875,7 +876,8 @@ class VelocityTransport2D(TransportCoefficients.TC_base):
                 div_vel_star = div_vel_last + dt/dt_last*( div_vel_last - div_vel_lastlast)
                 div_rho_vel_star = grad_rho[...,xi]*u_star + grad_rho[...,yi]*v_star + rho*div_vel_star
 
-
+        u_star = u
+        v_star = v
         #equation eu = 0
         # rho_sharp*u_t + rho(u_star u_x + v_star u_y ) + p_sharp_x - f1 + div(-mu grad(u))
         #            + 0.5( rho_t + rho_x u_star + rho_y v_star + rho div([u_star,v_star]) )u = 0

--- a/NavierStokesNotebooks/VariableDensityNavierStokes2D/density_p.py
+++ b/NavierStokesNotebooks/VariableDensityNavierStokes2D/density_p.py
@@ -17,7 +17,7 @@ coefficients=NavierStokes.DensityTransport2D(bdf=ctx.globalBDFTimeOrder,
                                              currentModelIndex=0,
                                              densityFunction=ctx.rhotrue,
                                              velocityModelIndex=1,  #don't change this unless the order in so-file is changed
-                                             velocityFunction=ctx.velocityFunction, #or ctx.velocityFunction to use exact solution (uncoupled transport)
+                                             velocityFunction=None, #or ctx.velocityFunction to use exact solution (uncoupled transport)
                                              divVelocityFunction=None, # or ctx.divVelocityFunction to use exact divergence solution
                                              useVelocityComponents=ctx.useVelocityComponents, #set to false to use 'velocity' (possible post-processed)
                                              pressureIncrementModelIndex=2,

--- a/NavierStokesNotebooks/VariableDensityNavierStokes2D/density_p.py
+++ b/NavierStokesNotebooks/VariableDensityNavierStokes2D/density_p.py
@@ -17,7 +17,7 @@ coefficients=NavierStokes.DensityTransport2D(bdf=ctx.globalBDFTimeOrder,
                                              currentModelIndex=0,
                                              densityFunction=ctx.rhotrue,
                                              velocityModelIndex=1,  #don't change this unless the order in so-file is changed
-                                             velocityFunction=None, #or ctx.velocityFunction to use exact solution (uncoupled transport)
+                                             velocityFunction=ctx.velocityFunction, #or ctx.velocityFunction to use exact solution (uncoupled transport)
                                              divVelocityFunction=None, # or ctx.divVelocityFunction to use exact divergence solution
                                              useVelocityComponents=ctx.useVelocityComponents, #set to false to use 'velocity' (possible post-processed)
                                              pressureIncrementModelIndex=2,

--- a/NavierStokesNotebooks/VariableDensityNavierStokes2D/navierstokes_vardensity.py
+++ b/NavierStokesNotebooks/VariableDensityNavierStokes2D/navierstokes_vardensity.py
@@ -30,7 +30,8 @@ setFirstTimeStepValues = True # interpolate the first step as well as the 0th st
 # setup time variables
 T = 1.0
 DT = 0.05  # target time step size
-
+#DT *=0.5
+#DT *=0.5
 # setup tnList
 if globalBDFTimeOrder == 1 or not useScaleUpTimeStepsBDF2:
     nFrames = int(T/DT) + 1
@@ -283,10 +284,10 @@ if unitCircle:
 
 
 # numerical tolerances
-density_atol_res = max(1.0e-8,0.01*he**2)
-velocity_atol_res = max(1.0e-8,0.01*he**2)
-phi_atol_res = max(1.0e-8,0.01*he**2)
-pressure_atol_res = max(1.0e-8,0.01*he**2)
+density_atol_res = 1.0e-10
+velocity_atol_res = 1.0e-10
+phi_atol_res = 1.0e-10
+pressure_atol_res = 1.0e-10
 
 
 parallelPartitioningType = proteus.MeshTools.MeshParallelPartitioningTypes.node

--- a/NavierStokesNotebooks/VariableDensityNavierStokes2D/navierstokes_vardensity.py
+++ b/NavierStokesNotebooks/VariableDensityNavierStokes2D/navierstokes_vardensity.py
@@ -30,8 +30,8 @@ setFirstTimeStepValues = True # interpolate the first step as well as the 0th st
 # setup time variables
 T = 1.0
 DT = 0.05  # target time step size
-#DT *=0.5
-#DT *=0.5
+DT *=0.5
+DT *=0.5
 # setup tnList
 if globalBDFTimeOrder == 1 or not useScaleUpTimeStepsBDF2:
     nFrames = int(T/DT) + 1


### PR DESCRIPTION
There was (at least) one more thing to do in postStep after we modify the solution, which is to re-evaluate the history in the timeIntegration.  I also turned off velocity extrapolation, but it may be that the extrapolation is working fine.  Couple of things to try and check that we don't loose the 2nd order convergence
- turn velocity extrapolation back on
- turn off analytical velocity solution in density
- check code for any other hacks
- re-enable non-analytical startup for first step

Here are the results  run with this commit over three refinements of DT (looks quadratic in rho and u). 

```
DT=0.05
rho
t= 1; error_u_L2[0][0]= 0.0020981;
u
t= 1; error_u_L2[0][0]= 0.000992537;
t= 1; error_u_H1[0][0]= 0.00605491;
v
t= 1; error_u_L2[1][0]= 0.00109142;
t= 1; error_u_H1[1][0]= 0.00638339;
p
t= 1; error_u_L2[0][0]= 0.0100527;
===
DT=0.025
rho
t= 1; error_u_L2[0][0]= 0.000527404;
u
t= 1; error_u_L2[0][0]= 0.000235266;
t= 1; error_u_H1[0][0]= 0.00194571;
v
t= 1; error_u_L2[1][0]= 0.000260666;
t= 1; error_u_H1[1][0]= 0.00201021;
p
t= 1; error_u_L2[0][0]= 0.00301679;
===
DT=0.0125
rho
t= 1; error_u_L2[0][0]= 0.000132081;
u
t= 1; error_u_L2[0][0]= 5.75997e-05;
t= 1; error_u_H1[0][0]= 0.000675337;
v
t= 1; error_u_L2[1][0]= 6.40324e-05;
t= 1; error_u_H1[1][0]= 0.00068726;
p
t= 1; error_u_L2[0][0]= 0.00100251;
```
